### PR TITLE
Added missing Edit Menu text to es.ini

### DIFF
--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -264,3 +264,38 @@ Tap=Cuando las flechas suban a este punto,\npisa el panel correspondiente.
 
 [ScreenMapControllers]
 Exit=Salir
+
+[ScreenEvaluation]
+HeaderText=Resultado
+
+[ScreenEditMenu]
+HeaderText=Editar canciones/pasos
+HeaderSubText=Haz canciones perfectas
+HelpText=&BACK; Salir &START; Seleccionar  &MENULEFT;&MENURIGHT;&MENUUP;&MENUDOWN; Mover  &SELECT; Regresar [PgUp][PgDown]  Saltar
+
+edit_description_prompt=Escribe una descripción para esta edición.
+delete_chart_prompt=¿Estás seguro de eliminar estos pasos?
+
+steps_action_back=Salir a los pasos
+copy_dest_slot_back=Salir a elegir estilo de juego
+copy_dest_style_back=Salir a elegir archivo a copiar
+copy_from_back=Salir a elegir archivo a editar
+new_chart_slot_back=Salir a elegir tipo de pasos
+new_chart_stype_back=Salir a elegir pasos a editar
+steps_list_back=Salir a elegir canción
+song_list_back=Salir a elegir grupo
+exit_edit_menu=Salir del modo editar
+
+edit_chart=Editar pasos
+delete_chart=Eliminar pasos
+new_chart=Nuevos pasos
+copy_from=Crear nueva copia
+
+copy_to_slot_format=Copiar a  %s %s
+new_chart_slot_format=Nuevo - %s %s
+
+copy_dest_slot_menu=Elige la dificultad para los nuevos pasos.
+copy_dest_stype_menu=Elige el tipo de notas para los nuevos pasos.
+copy_from_menu=Elige los pasos a copiar.
+new_chart_slot_menu=Elige la dificultad para los pasos.
+new_chart_stype_menu=Elige el tipo de notas para los pasos.


### PR DESCRIPTION
Edit Menu text was completely missing from es.ini, so I added it and translated it myself.