### PR TITLE
Change string.upper to newer ToUpper in PaneDisplay text.lua

### DIFF
--- a/Graphics/PaneDisplay text.lua
+++ b/Graphics/PaneDisplay text.lua
@@ -21,7 +21,7 @@ end;
 local function CreatePaneDisplayItem( _pnPlayer, _sLabel, _rcRadarCategory )
 	return Def.ActorFrame {
 		LoadFont("_open sans condensed 24px") .. {
-			Text=string.upper( THEME:GetString("PaneDisplay",_sLabel) );
+			Text=ToUpper( THEME:GetString("PaneDisplay",_sLabel) );
 			InitCommand=function(self) self:horizalign(left) end;
 			OnCommand=function(self) self:zoom(0.8):diffuse(color("0.9,0.9,0.9")):skewx(-0.1):shadowlength(1) end;
 		};


### PR DESCRIPTION
I only changed one line from 5.x's ``string.upper`` to Outfox exclusive ``ToUpper``

This is just a very minor fix to a problem that exists only while using some languages (Polish for example).

From:
![2021-04-03_225002](https://user-images.githubusercontent.com/63615036/113491477-54665380-94d1-11eb-84e0-102a9764a32d.png)

To:
![2021-04-03_225031](https://user-images.githubusercontent.com/63615036/113491480-57f9da80-94d1-11eb-91a6-1a581046d261.png)

(And yes, I changed one line to fix just two characters in a theme)